### PR TITLE
Add component helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# Dust Component Helper
+# Dust.JS Component Helper

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,35 @@
+{
+  "name": "dustjs-component-helper",
+  "description": "Encapsulated, composable components in Dust",
+  "version": "0.0.1",
+  "authors": [
+    "Ryan Frederick <ryan@ryanfrederick.com>"
+  ],
+  "keywords": [
+    "dust",
+    "components",
+    "helper"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ry5n/dustjs-component-helper.git"
+  },
+  "main": "index.js",
+  "moduleType": [
+    "amd",
+    "globals",
+    "node"
+  ],
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "dustjs-linkedin": "~2.6.1",
+    "umd-function-bind": "ry5n/umd-function-bind#~1.1.0"
+  }
+}

--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,6 @@
     "tests"
   ],
   "dependencies": {
-    "dustjs-linkedin": "~2.6.1",
-    "umd-function-bind": "ry5n/umd-function-bind#~1.1.0"
+    "dustjs-linkedin": "~2.6.1"
   }
 }

--- a/index.js
+++ b/index.js
@@ -75,7 +75,6 @@
       // as part of the view. To accomplish this, we replace the dust body with
       // a proxy that passes in the original (outer) context instead of the
       // component context.
-
       var proxy = (function(bodyFn) {
         return function() {
           bodyFn(chunk, originalContext);

--- a/index.js
+++ b/index.js
@@ -1,13 +1,14 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['dustjs-linkedin'], factory);
+    define(['dustjs-linkedin', 'umd-function-bind'], factory);
   } else if (typeof exports === 'object') {
-    module.exports = factory(require('dustjs-linkedin'));
+    module.exports = factory(require('dustjs-linkedin'), require('umd-function-bind'));
   } else {
     factory(root.dust);
   }
-}(this, function(dust) {
+}(this, function(dust, bind) {
 
+  Function.prototype.bind = Function.prototype.bind || bind;
   dust.helpers = dust.helpers || {};
 
   dust.helpers.component = function component(chunk, context, bodies, params) {

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@
   dust.helpers.component = function component(chunk, context, bodies, params) {
 
     // The component name is required to load and render the template.
-    if (!params.name) {
+    if (!params.is) {
       return chunk;
     }
 
@@ -28,13 +28,13 @@
     var componentContext = dust.makeBase(context.global);
 
     // Set the template to render.
-    var templateName = componentContext.templateName = params.name;
+    var templateName = componentContext.templateName = params.is;
 
     // Params to be passed to the component template.
     var componentParams = [];
 
     // Some param names are reserved:
-    // - `name` is for choosing the component to render and isn’t passed to
+    // - `is` is for choosing the component to render and isn’t passed to
     //   the template.
     // - `ctx` is reserved for passing the entire component context in one
     //   param, which is sometimes convenient. Even though Dust has its own
@@ -44,7 +44,7 @@
     //   not passed to the template.
     // - `body` is reserved as the key in which the default dust body is
     //   provided to the template. It therefore can’t be used as a param name.
-    var reservedParamNames = ['name', 'ctx', 'body'];
+    var reservedParamNames = ['is', 'ctx', 'body'];
 
     // If and only if an explit context was provided, set up that context.
     // Otherwise, the context available to the component template is limited

--- a/index.js
+++ b/index.js
@@ -1,1 +1,102 @@
-// Write the helper here :)
+(function(root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define(['dustjs-linkedin'], factory);
+  } else if (typeof exports === 'object') {
+    module.exports = factory(require('dustjs-linkedin'));
+  } else {
+    factory(root.dust);
+  }
+}(this, function(dust) {
+
+  dust.helpers = dust.helpers || {};
+
+  dust.helpers.component = function component(chunk, context, bodies, params) {
+
+    // The component name is required to load and render the template.
+    if (!params.name) {
+      return chunk;
+    }
+
+    bodies = bodies || {};
+    params = params || {};
+
+    // Keep a clear reference to the original context.
+    var originalContext = context;
+
+    // By default, components are completely isolated from the outside template
+    // context. So we start with a new, empty context.
+    var componentContext = dust.makeBase(context.global);
+
+    // Set the template to render.
+    var templateName = componentContext.templateName = params.name;
+
+    // Params to be passed to the component template.
+    var componentParams = [];
+
+    // Some params names are reserved:
+    // - `name` is for choosing the component to render and isn’t passed to
+    //   the template.
+    // - `ctx` is reserved for passing the entire component context in one
+    //   param, which is sometimes convenient. Even though Dust has its own
+    //   {tag:context /} syntax for this, We can’t respect it because in a
+    //   helper there is no way to differentiate explicit from inherited
+    //   context, and we’re avoiding inherited context by design. This param is
+    //   not passed to the template.
+    // - `body` is reserved as the key in which the default dust body is
+    //   provided to the template. It therefore can’t be used as a param name.
+    var reservedParamNames = ['name', 'ctx', 'body'];
+
+    // If and only if an explit context was provided, set up that context.
+    // Otherwise, the context available to the component template is limited
+    // to the params and bodies passed in.
+    if (params.ctx) {
+      componentContext.blocks = context.blocks;
+
+      if (context.stack && context.stack.tail) {
+        // Grab the tail off of the previous context if we have it.
+        componentContext.stack = context.stack.tail;
+      }
+
+      // Reattach the head.
+      componentContext = componentContext.push(context.stack.head);
+    }
+
+    // Process params and make them available to the template, filtering out
+    // reserved param names.
+    for (var name in params) {
+      if (reservedParamNames.indexOf(name) === -1) {
+        componentParams[name] = params[name];
+      }
+    }
+
+    // Process bodies. These will always override params of the same name.
+    for (var name in bodies) {
+
+      // Dust bodies are of the form fn(chunk, context). We want bodies to have
+      // access to the original (outer) context so the developer can treat them
+      // as part of the view. To accomplish this, we replace the dust body with
+      // a proxy that passes in the original (outer) context instead of the
+      // component context.
+      var proxy = function(chunk, context) {
+        return this(chunk, originalContext);
+      }.bind(bodies[name])
+
+      // The default (unnamed) body is referred to internally as `block`. For
+      // usability reasons, we expose this in the template as the `body` key
+      // instead.
+      if (name === 'block') {
+        componentParams['body'] = proxy;
+      } else {
+        componentParams[name] = proxy;
+      }
+    }
+
+    // Make the new params available to the component template.
+    componentContext = componentContext.push(componentParams);
+
+    // Return the evaluated template.
+    return dust.load(templateName, chunk, componentContext);
+  }
+
+  return dust;
+}));

--- a/index.js
+++ b/index.js
@@ -50,15 +50,13 @@
     // Otherwise, the context available to the component template is limited
     // to the params and bodies passed in.
     if (params.ctx) {
-      componentContext.blocks = context.blocks;
+      componentContext = componentContext.push(params.ctx);
 
-      if (context.stack && context.stack.tail) {
-        // Grab the tail off of the previous context if we have it.
-        componentContext.stack = context.stack.tail;
+      // The empty context created above is now set as the tail; we can safely
+      // remove it.
+      if (componentContext.stack) {
+        componentContext.stack.tail = undefined;
       }
-
-      // Reattach the head.
-      componentContext = componentContext.push(context.stack.head);
     }
 
     // Process params and make them available to the template, filtering out

--- a/index.js
+++ b/index.js
@@ -76,8 +76,8 @@
       // a proxy that passes in the original (outer) context instead of the
       // component context.
       var proxy = (function(bodyFn) {
-        return function() {
-          bodyFn(chunk, originalContext);
+        return function(bodyChunk) {
+          bodyFn(bodyChunk, originalContext);
         }
       })(bodies[name]);
 

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@
     // Params to be passed to the component template.
     var componentParams = [];
 
-    // Some params names are reserved:
+    // Some param names are reserved:
     // - `name` is for choosing the component to render and isn’t passed to
     //   the template.
     // - `ctx` is reserved for passing the entire component context in one

--- a/index.js
+++ b/index.js
@@ -1,14 +1,13 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['dustjs-linkedin', 'umd-function-bind'], factory);
+    define(['dustjs-linkedin'], factory);
   } else if (typeof exports === 'object') {
-    module.exports = factory(require('dustjs-linkedin'), require('umd-function-bind'));
+    module.exports = factory(require('dustjs-linkedin'));
   } else {
     factory(root.dust);
   }
-}(this, function(dust, bind) {
+}(this, function(dust) {
 
-  Function.prototype.bind = Function.prototype.bind || bind;
   dust.helpers = dust.helpers || {};
 
   dust.helpers.component = function component(chunk, context, bodies, params) {
@@ -76,9 +75,12 @@
       // as part of the view. To accomplish this, we replace the dust body with
       // a proxy that passes in the original (outer) context instead of the
       // component context.
-      var proxy = function(chunk, context) {
-        return this(chunk, originalContext);
-      }.bind(bodies[name])
+
+      var proxy = (function(bodyFn) {
+        return function() {
+          bodyFn(chunk, originalContext);
+        }
+      })(bodies[name]);
 
       // The default (unnamed) body is referred to internally as `block`. For
       // usability reasons, we expose this in the template as the `body` key

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "dustjs-linkedin": "~2.6.1",
-    "umd-function-bind": "ry5n/umd-function-bind#1.1.0"
+    "dustjs-linkedin": "~2.6.1"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -1,19 +1,25 @@
 {
-  "name": "dust-component-helper",
+  "name": "dustjs-component-helper",
   "description": "Encapsulated, composable components in Dust",
   "version": "0.0.1",
-  "author": "Ryan L Frederick <ryan@ryanfrederick.com> (http://ryanfrederick.com/)",
+  "author": "Ryan L Frederick",
+  "keywords": [
+    "dust",
+    "components",
+    "helper"
+  ],
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ry5n/dust-component-helper.git"
+    "url": "https://github.com/ry5n/dustjs-component-helper.git"
   },
   "main": "index.js",
   "scripts": {
     "test": "grunt test"
   },
   "dependencies": {
-    "dustjs-linkedin": "~2.6.1"
+    "dustjs-linkedin": "~2.6.1",
+    "umd-function-bind": "ry5n/umd-function-bind#1.1.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",

--- a/test/test.js
+++ b/test/test.js
@@ -25,7 +25,7 @@ describe('component helper', function() {
   });
 
   it('has strong encapsulation by default.', function() {
-    var code = '{@component name="example" /}';
+    var code = '{@component is="example" /}';
 
     dust.renderSource(code, context, function(err, out) {
       assert.equal(out, '<div class="c-example"></div>');
@@ -33,7 +33,7 @@ describe('component helper', function() {
   });
 
   it('accepts literals in params.', function() {
-    var code = '{@component name="example" isFeatured="true" /}';
+    var code = '{@component is="example" isFeatured="true" /}';
 
     dust.renderSource(code, context, function(err, out) {
       assert.equal(out, '<div class="c-example c--featured"></div>');
@@ -41,7 +41,7 @@ describe('component helper', function() {
   });
 
   it('accepts objects from the current context in params.', function() {
-    var code = '{@component name="example" state=state /}';
+    var code = '{@component is="example" state=state /}';
 
     dust.renderSource(code, context, function(err, out) {
       assert.equal(out, '<div class="c-example"><p>Faved!</p></div>');
@@ -49,7 +49,7 @@ describe('component helper', function() {
   });
 
   it('accepts body content.', function() {
-    var code = '{@component name="example"}<p><em>Yay!</em></p>{/component}';
+    var code = '{@component is="example"}<p><em>Yay!</em></p>{/component}';
 
     dust.renderSource(code, context, function(err, out) {
       assert.equal(out, '<div class="c-example"><p><em>Yay!</em></p></div>');
@@ -57,7 +57,7 @@ describe('component helper', function() {
   });
 
   it('accepts multiple bodies.', function() {
-    var code = '{@component name="example"}<p><em>Yay!</em></p>{:other}<p><strong>Boom!</strong></p>{/component}';
+    var code = '{@component is="example"}<p><em>Yay!</em></p>{:other}<p><strong>Boom!</strong></p>{/component}';
 
     dust.renderSource(code, context, function(err, out) {
       assert.equal(out, '<div class="c-example"><p><em>Yay!</em></p><p><strong>Boom!</strong></p></div>');
@@ -65,7 +65,7 @@ describe('component helper', function() {
   });
 
   it('evaluates bodies in the context of the outer template.', function() {
-    var code ='{@component name="example"}<p><em>{passed}</em></p>{:other}<p><strong>{?state.faved}Faved!{/state.faved}</strong></p>{/component}';
+    var code ='{@component is="example"}<p><em>{passed}</em></p>{:other}<p><strong>{?state.faved}Faved!{/state.faved}</strong></p>{/component}';
 
     dust.renderSource(code, context, function(err, out) {
       assert.equal(out, '<div class="c-example"><p><em>Passed!</em></p><p><strong>Faved!</strong></p></div>');
@@ -73,7 +73,7 @@ describe('component helper', function() {
   });
 
   it('handles params and bodies at the same time.', function() {
-    var code ='{@component name="example" isFeatured="true" state=state}<p><em>{passed}</em></p>{:other}<p>Template name is <strong>{example}</strong></p>{/component}';
+    var code ='{@component is="example" isFeatured="true" state=state}<p><em>{passed}</em></p>{:other}<p>Template name is <strong>{example}</strong></p>{/component}';
 
     dust.renderSource(code, context, function(err, out) {
       assert.equal(out, '<div class="c-example c--featured"><p><em>Passed!</em></p><p>Template name is <strong>example</strong></p><p>Faved!</p></div>');
@@ -81,7 +81,7 @@ describe('component helper', function() {
   });
 
   it('handles (nested) components in bodies.', function() {
-    var code ='{@component name="example" isFeatured="true" state=state}<p><em>{passed}</em></p>{:other}{@component name="example"}<blockquote>I am nested!</blockquote>{/component}{/component}';
+    var code ='{@component is="example" isFeatured="true" state=state}<p><em>{passed}</em></p>{:other}{@component is="example"}<blockquote>I am nested!</blockquote>{/component}{/component}';
 
     dust.renderSource(code, context, function(err, out) {
       assert.equal(out, '<div class="c-example c--featured"><p><em>Passed!</em></p><div class="c-example"><blockquote>I am nested!</blockquote></div><p>Faved!</p></div>');
@@ -89,7 +89,7 @@ describe('component helper', function() {
   });
 
   it('cannot force the component’s context using the native syntax.', function() {
-    var code ='{@component:. name="example"}{/component}';
+    var code ='{@component:. is="example"}{/component}';
 
     dust.renderSource(code, context, function(err, out) {
       assert.equal(out, '<div class="c-example"></div>');
@@ -97,7 +97,7 @@ describe('component helper', function() {
   });
 
   it('can force the component’s context via the `ctx` param.', function() {
-    var code ='{@component name="example" ctx=.}{/component}';
+    var code ='{@component is="example" ctx=.}{/component}';
 
     dust.renderSource(code, context, function(err, out) {
       assert.equal(out, '<div class="c-example"><p>Outer</p><p>Faved!</p></div>');


### PR DESCRIPTION
Adds a dust helper that addresses the issues I’ve run into working with UI components in Dust JS. In short, this allows:
- Declarative composition of component templates in a way similar to Web Components. This is accomplished by passing the body (or bodies) of the Dust helper as params to the template. Importantly, bodies are evaluated using the “outer” (view) context so we can treat their content as effectively part of the view.
- Data isolation: by default no data enters a component except through Dust params and bodies.
- Predictability: since the component context is isolated, Dust won’t walk the context stack looking for keys, preventing accidental key access and improving testability.

An example of the syntax this makes possible:

``` dust
{@component is="pinny" title=sidebarTitle}
    <p>Body content. This can be anything, including other components and no limit on nesting.</p>

    {! for example !}
    {#sidebarSections}
        {@component is="another-component" class="c--fancy"}
            {sectionContent}
        {/component}
    {/sidebarSections}
{:footer}
    <p>Components can have multiple bodies! (Additional bodies are named – in this case, `footer`.)</p>
{/component}
```

**Note**: This helper relies on component templates having been [compiled under a name](https://github.com/linkedin/dustjs/wiki/Dust-Tutorial#Compiling_a_Dust_template).

Status: **Opened for comment**

Reviewers: Tools team (@tedtate @donnielrt @jeffkamo) and any other interested folks 
Ticket: https://mobify.atlassian.net/browse/CSOPS-1277
Linked PRs: none
## Changes
- Adds component helper code; tests are already in place.
## How to test-drive this PR
1. Review code
2. Run tests
   - Clone this repo and `cd` in
   - `npm install`
   - `git checkout component-helper`
   - `grunt test`
## Research resources
- [Dust issues](https://gist.github.com/ry5n/1455a1dbf2b6ff56fcfd): short explainer document
- [Original attempt](https://github.com/mobify/dustjs/pull/2): this is the same idea, but is a fork of Dust itself (it does allow nicer syntax).
- [Ember Components](http://emberjs.com/api/classes/Ember.Component.html): a very similar idea
## Todo
- [ ] Engineer Review
- [ ] Engineer Approval
